### PR TITLE
Fix bug with URL formatting form error message

### DIFF
--- a/handleUser.js
+++ b/handleUser.js
@@ -53,7 +53,7 @@ var saveUser = function (model, data, host, callback) {
                        .replace(/^https?:\/\//, '');
       if (!validator.isURL(urls[i])) {
         console.log('Bad URL: ', urls[i]);
-        errors += 'Poorly formatted URL: "' + data.email + '".<br>';
+        errors += 'Poorly formatted URL: "' + urls[i] + '".<br>';
       }
     }
     data.urls = urls;


### PR DESCRIPTION
r? @machyne — is this an actual bug? It was saying my email was an improperly formatted URL. Also, does this need to be escaped?
