### PR TITLE
Copyedits

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CarlHacks Website
 1. Change into the new repo's directory with `cd website`.
 1. Install dependencies with `npm install`.
 1. Then do `npm install stylus`.
-1. Then do `touch "api_keys.js`.
+1. Then do `touch api_keys.js`.
 1. Start the Node server with `npm start`.
 1. Visit <http://localhost:8080> to see the site!
 

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -26,7 +26,7 @@ a:hover {
   justify-content: center;
   -webkit-align-items: center;
   align-items: center;
-  background: radial-gradient(circle at bottom left, rgba(46, 49, 146, 0.84) 0%, rgba(12, 13, 42, 0.84) 80%), url(/img/herobg.jpg) center center/cover;
+  background: radial-gradient(circle at bottom left, rgba(46, 49, 146, 0.74) 0%, rgba(12, 13, 42, 0.74) 80%), url(/img/herobg.jpg) center center/cover;
   color: #fff;
   position: relative; /* for transparent background hack */
   padding: 9em 0;

--- a/views/index.jade
+++ b/views/index.jade
@@ -40,46 +40,45 @@ block page
     section.card.left.info
       h1 Event Details
       p
-        | Hosted by Carleton College in Northfield, MN, CarlHacks is a 36-hour overnight event where teams work
-        | together to build interesting apps, websites, and games, and other projects.
+        | Hosted by Carleton College in Northfield, Minnesota, CarlHacks is a 36-hour overnight event where teams work
+        | together to build interesting apps, websites, games, and other projects.
       p
-        | At CarlHacks, <strong>any student who is or was enrolled in an undergraduate
-        | collegiate institution during the 2014&ndash;2015 academic year</strong> is eligible
-        | to participate in <strong>teams of 2&ndash;5</strong>.
-        | You don’t need meaningful coding experience to participate&mdash;hackathons are a great opportunity
-        | to learn new skills or hone old ones. Whether you’re a graphic designer or a dedicated
+        | <strong>Any student who is or was enrolled in an undergraduate
+        | collegiate institution during the 2014&ndash;2015 academic year is eligible
+        | to participate in teams of 2&ndash;5</strong>.
+        | You don’t need past coding experience to participate. Hackathons are a great opportunity
+        | to learn new skills or hone old ones, and whether you’re a graphic designer or a dedicated
         | Python enthusiast (or both!), you can make an important contribution to a CarlHacks project.
-        | We’ll also have sponsors and mentors on-site to help hackers expand their coding and design abilities.
-        | At the end of the event, teams may choose to submit their projects for judging,
-        | and prizes are awarded to the best projects in a variety of categories. Even if you choose not to submit
-        | a project for judging, you’ll leave CarlHacks with more tools to make your future aspirations a reality.
+        | Teams may choose to submit their projects for judging and prizes will be awarded
+        | to the best projects in a variety of categories. Even if you choose not to submit
+        | your project for judging, you’ll leave CarlHacks with tools to make your
+        | future aspirations a reality.
+
+      h2 The Venue
+      p
+        | The Carleton College Recreation Center Fieldhouse has showers, sinks, bathrooms, and a
+        | bouldering wall, and boasts enough space for 400 hackers plus our sponsors.
+        | The Rec Center is also mere steps from Carleton’s 880-acre arboretum, offering
+        | a convenient venue for outdoor adventures when you need a break from your screen.
 
       h2 What to Bring
       p
-        | <strong>You will need to bring your laptop, charger, your student ID card</strong>, and any hardware
-        | you intend to use in your hack. It is also strongly recommended that you bring
-        | toiletries, shower shoes, a change of clothing, and a pillow. CarlHacks is completely free to attend, and
-        | we'll provide meals, showers, and air beds for napping. You don’t need to have a project
-        | idea before the hackathon begins&mdash;some of the best ideas happen during hackathons, not
-        | before. You don’t even need to form a team before the hackathon! We will facilitate a “speed-dating”
+        | CarlHacks is completely free to attend, and we'll provide meals, showers, and air beds for napping.
+        | <strong>You will need to bring your laptop, charger, student ID card</strong>, and any hardware
+        | you intend to use in your hack. Toiletries, shower shoes, a change of clothing, and a pillow
+        | are strongly recommended. A project idea is not needed beforehand&mdash;some of the best ideas happen
+        | during hackathons, not before. Don't worry if you don't have a team since we will facilitate a “speed-dating”
         | period to help hackers form teams at the beginning of the event.
-      h2 The Venue
-      p
-        | CarlHacks will be held in the Carleton College Recreation Center Fieldhouse. This space
-        | has showers, sinks, bathrooms, and a bouldering wall on-site, and boasts enough space for 400 hackers
-        | (and sponsors). The Rec Center is also mere steps from Carleton’s 880 acre arboretum, providing
-        | a convenient venue for outdoor adventures if you need a break from your screen.
+
       h2 Networking and Learning
       p
-        | At CarlHacks, both sponsors and mentors will be available for connecting and networking.
+        | We encourage CarlHacks attendees to connect with sponsors and mentors at the event.
         | Mentors will be great resources for targeted learning, and will run workshops and walk the floor
         | to answer questions.
       p
         | Representatives from our sponsors will also be present at the event, manning tables around the perimeter
-        | or circulating through the project areas. This is a wonderful opportunity to talk with current employees
-        | or plan a future interview.
-
-      p More information on sponsors and workshop schedules will be available as the event approaches.
+        | and circulating through the project areas. This is a wonderful opportunity to talk with current employees
+        | or plan a future interview. More info on sponsors and workshop schedules will be available as the event approaches.
     div.card.divider
       img(src='/img/photo-card-2.jpg')
     //- section.card.right.schedule
@@ -88,21 +87,26 @@ block page
     //-     | <em>Talks, workshops, and other activities will be added as they are scheduled</em>
     section.card.left.transport
       h1 Transportation
-      h2 From Minneapolis&ndash;St.Paul
-      p For people coming to CarlHacks from the Twin Cities, we will be organizing a few bus pickup and drop-off locations for transportation to and from Carleton College.
-      p Bus stop locations and times will be determined after registration closes (early April)
-      h2 From the Airport
-      p There will be several bus pickup and drop-off times at the MSP Transit Center in Terminal 1-Lindbergh.
+      p
+        | Travel reimbursements will be available, and reimbursement decisions will be
+        | released with application decisions in early April. Buses will be available for
+        | pick up and drop off at Terminal 1 at the MSP airport.
+      h2 From Minneapolis&ndash;Saint Paul
+      p
+        | We will organize buses for transportation
+        | between Carleton College and the Twin Cities.
+        | Exact locations and times will be determined after registration closes.
       h2 Personal Vehicles
-      p If you are driving a personal vehicle to and from the event, parking location information and parking passes will be issued at a later date.
+      p
+        | For those planning to drive a personal vehicle to and from the event,
+        | parking location information and parking passes will be issued
+        | at a later date.
     div.card.divider
       img(src='/img/photo-card-4.jpg')
     section.card
       h1 Become a Sponsor or Mentor
       p
         | Want to help new hackers learn and experienced hackers grow?
-        | Participate in CarlHacks as a mentor or a sponsor!
-      p
         | To volunteer as a CarlHacks mentor, contact us at
         = ' '
         a(href="mailto:mentor@carlhacks.io?subject=Mentor+CarlHacks")
@@ -110,19 +114,19 @@ block page
         | . We would love to have you run a workshop, walk the floor and
         | answer questions, or contribute your expertise in some other way.
       p
-        | Want to get your company involved? Sponsors will not only help
-        | make CarlHacks a possibility through their donations, but
-        | will also have the opportunity to represent their brand and
+        | Want to get your company involved? Sponsors 
+        | will have the opportunity to represent their brand and
         | connect with some of the top students in the Midwest and beyond.
-        | Email us at
+        | Take a look at
+        = ' '
+        a(href="/pdf/sponsorship.pdf") our sponsorship tiers
+        = ' '
+        | and email us at
         = ' '
         a(href="mailto:sponsor@carlhacks.io?subject=Sponsor+CarlHacks")
           | sponsor@carlhacks.io
         = ' '
-        | to learn more about sponsoring CarlHacks, or take a look at
-        = ' '
-        a(href="/pdf/sponsorship.pdf") our sponsorship tiers
-        | .
+        | to learn more about sponsoring CarlHacks.
 
     section.signup
       a.register(href='/apply') Apply


### PR DESCRIPTION
I think the page is a little too wordy, and we could do better to make CarlHacks look awesome by emphasizing the parts that are going to be awesome. Other concerns: people familiar with hackathons will be looking for only a few things: reimbursement for flights, sponsors, prizes, deadlines—which are not easy to find right now without reading several paragraphs of text. More photos would be cool but not easy since it would require reconsidering the design.

**my changes**: Nothing major, but tried to cut down words without cutting content. If the diffs are hard to read, check out this screenshot for a side-by-side comparison of the Event Details https://www.dropbox.com/s/xaxzfokw3x71bec/Screenshot%202015-03-08%2017.15.47.png?dl=0
